### PR TITLE
Fix PF_RING WritePacketData rv error

### DIFF
--- a/pfring/pfring.go
+++ b/pfring/pfring.go
@@ -209,7 +209,7 @@ func (r *Ring) RemoveBPFFilter() error {
 // WritePacketData uses the ring to send raw packet data to the interface.
 func (r *Ring) WritePacketData(data []byte) error {
 	buf := (*C.char)(unsafe.Pointer(&data[0]))
-	if rv := C.pfring_send(r.cptr, buf, C.u_int(len(data)), 1); rv != 0 {
+	if rv := C.pfring_send(r.cptr, buf, C.u_int(len(data)), 1); rv < 0 {
 		return fmt.Errorf("Unable to send packet data, got error code %d", rv)
 	}
 	return nil


### PR DESCRIPTION
C.pfring_send return the number of bytes sent.
https://github.com/ntop/PF_RING/blob/6.2.0-stable/userland/lib/pfring.h#L630

rv >= 0 value is not an error but the number of bytes sent.
